### PR TITLE
Fix the issue that trace_sql_parameter argument is invalid for oracle db plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,5 @@ before_install:
   - cd ..
 
 install:
-  - jdk_switcher use oraclejdk8
   - ./mvnw clean install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: java
 before_install:
   - mkdir ci-dependencies
   - cd ci-dependencies
-  - curl -O https://openskywalking.github.io/skywalking-ci-assist/jars/ojdbc14-10.2.0.4.0.jar
+  - curl -O https://github.com/SkyAPM/ci-assist/blob/master/jars/ojdbc14-10.2.0.4.0.jar
   - mvn install:install-file  -Dfile=ojdbc14-10.2.0.4.0.jar  -DgroupId=com.oracle  -DartifactId=ojdbc14 -Dversion=10.2.0.4.0 -Dpackaging=jar
-  - curl -O https://openskywalking.github.io/skywalking-ci-assist/jars/resin-4.0.41.jar
+  - curl -O https://github.com/SkyAPM/ci-assist/blob/master/jars/resin-4.0.41.jar
   - mvn install:install-file  -Dfile=resin-4.0.41.jar  -DgroupId=com.caucho  -DartifactId=resin -Dversion=4.0.41 -Dpackaging=jar
   - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: java
 before_install:
   - mkdir ci-dependencies
   - cd ci-dependencies
-  - curl -O https://github.com/SkyAPM/ci-assist/blob/master/jars/ojdbc14-10.2.0.4.0.jar
+  - curl -O https://skyapm.github.io/ci-assist/jars/ojdbc14-10.2.0.4.0.jar
   - mvn install:install-file  -Dfile=ojdbc14-10.2.0.4.0.jar  -DgroupId=com.oracle  -DartifactId=ojdbc14 -Dversion=10.2.0.4.0 -Dpackaging=jar
-  - curl -O https://github.com/SkyAPM/ci-assist/blob/master/jars/resin-4.0.41.jar
+  - curl -O https://skyapm.github.io/ci-assist/jars/resin-4.0.41.jar
   - mvn install:install-file  -Dfile=resin-4.0.41.jar  -DgroupId=com.caucho  -DartifactId=resin -Dversion=4.0.41 -Dpackaging=jar
   - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ before_install:
   - cd ..
 
 install:
-  - ./mvnw clean install
+  - mvn clean install
 

--- a/oracle-10.x-plugin/src/main/java/io/skywalking/apm/plugin/jdbc/oracle/PreparedStatementExecuteMethodsInterceptor.java
+++ b/oracle-10.x-plugin/src/main/java/io/skywalking/apm/plugin/jdbc/oracle/PreparedStatementExecuteMethodsInterceptor.java
@@ -39,6 +39,10 @@ public class PreparedStatementExecuteMethodsInterceptor implements InstanceMetho
   
     public static final StringTag SQL_PARAMETERS = new StringTag("db.sql.parameters");
 
+    /**
+     * 2020-12-01 ray_bi modified
+     * Add a new section to trace sql parameter
+     */
     @Override
     public final void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments,
         Class<?>[] argumentsTypes,

--- a/oracle-10.x-plugin/src/main/java/io/skywalking/apm/plugin/jdbc/oracle/PreparedStatementExecuteMethodsInterceptor.java
+++ b/oracle-10.x-plugin/src/main/java/io/skywalking/apm/plugin/jdbc/oracle/PreparedStatementExecuteMethodsInterceptor.java
@@ -20,12 +20,15 @@ package io.skywalking.apm.plugin.jdbc.oracle;
 
 import java.lang.reflect.Method;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.StringTag;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.plugin.jdbc.JDBCPluginConfig;
+import org.apache.skywalking.apm.plugin.jdbc.PreparedStatementParameterBuilder;
 import org.apache.skywalking.apm.plugin.jdbc.define.StatementEnhanceInfos;
 import org.apache.skywalking.apm.plugin.jdbc.trace.ConnectionInfo;
 
@@ -33,6 +36,8 @@ import org.apache.skywalking.apm.plugin.jdbc.trace.ConnectionInfo;
  * @author zhang xin
  */
 public class PreparedStatementExecuteMethodsInterceptor implements InstanceMethodsAroundInterceptor {
+  
+    public static final StringTag SQL_PARAMETERS = new StringTag("db.sql.parameters");
 
     @Override
     public final void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments,
@@ -41,12 +46,22 @@ public class PreparedStatementExecuteMethodsInterceptor implements InstanceMetho
         StatementEnhanceInfos cacheObject = (StatementEnhanceInfos)objInst.getSkyWalkingDynamicField();
         if (cacheObject != null && cacheObject.getConnectionInfo() != null) {
             ConnectionInfo connectInfo = cacheObject.getConnectionInfo();
-
             AbstractSpan span = ContextManager.createExitSpan(buildOperationName(connectInfo, method.getName(), cacheObject.getStatementName()), connectInfo.getDatabasePeer());
             Tags.DB_TYPE.set(span, "sql");
             Tags.DB_INSTANCE.set(span, connectInfo.getDatabaseName());
             Tags.DB_STATEMENT.set(span, cacheObject.getSql());
             span.setComponent(connectInfo.getComponent());
+
+            //tarce sql parameters. 
+            if(JDBCPluginConfig.Plugin.JDBC.TRACE_SQL_PARAMETERS){
+              Object[] parameters = cacheObject.getParameters();
+              if(parameters!=null && parameters.length>0){
+                int maxIndex = cacheObject.getMaxIndex();
+                String parameterString = getParameterString(parameters, maxIndex);
+                SQL_PARAMETERS.set(span, parameterString);
+              }
+            }
+
             SpanLayer.asDB(span);
         }
     }
@@ -74,5 +89,13 @@ public class PreparedStatementExecuteMethodsInterceptor implements InstanceMetho
 
     private String buildOperationName(ConnectionInfo connectionInfo, String methodName, String statementName) {
         return connectionInfo.getDBType() + "/JDBI/" + statementName + "/" + methodName;
+    }
+
+
+    private String getParameterString(Object[] parameters, int maxIndex) {
+      return new PreparedStatementParameterBuilder()
+          .setParameters(parameters)
+          .setMaxIndex(maxIndex)
+          .build();
     }
 }

--- a/oracle-10.x-plugin/src/main/java/io/skywalking/apm/plugin/jdbc/oracle/PreparedStatementExecuteMethodsInterceptor.java
+++ b/oracle-10.x-plugin/src/main/java/io/skywalking/apm/plugin/jdbc/oracle/PreparedStatementExecuteMethodsInterceptor.java
@@ -40,8 +40,7 @@ public class PreparedStatementExecuteMethodsInterceptor implements InstanceMetho
     public static final StringTag SQL_PARAMETERS = new StringTag("db.sql.parameters");
 
     /**
-     * 2020-12-01 ray_bi modified
-     * Add a new section to trace sql parameter
+     * Add a new section to trace sql parameter.
      */
     @Override
     public final void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments,

--- a/oracle-10.x-plugin/src/main/java/io/skywalking/apm/plugin/jdbc/oracle/define/OraclePrepareStatementSetterInstrumentation.java
+++ b/oracle-10.x-plugin/src/main/java/io/skywalking/apm/plugin/jdbc/oracle/define/OraclePrepareStatementSetterInstrumentation.java
@@ -20,7 +20,10 @@ package io.skywalking.apm.plugin.jdbc.oracle.define;
 
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
 import org.apache.skywalking.apm.plugin.jdbc.PSSetterDefinitionOfJDBCInstrumentation;
-
+/**
+ * @author ray_bi
+ * @since 2020-12-01
+ */
 public class OraclePrepareStatementSetterInstrumentation extends OraclePrepareStatementInstrumentation {
 
 

--- a/oracle-10.x-plugin/src/main/java/io/skywalking/apm/plugin/jdbc/oracle/define/OraclePrepareStatementSetterInstrumentation.java
+++ b/oracle-10.x-plugin/src/main/java/io/skywalking/apm/plugin/jdbc/oracle/define/OraclePrepareStatementSetterInstrumentation.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skywalking.apm.plugin.jdbc.oracle.define;
+
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
+import org.apache.skywalking.apm.plugin.jdbc.PSSetterDefinitionOfJDBCInstrumentation;
+
+public class OraclePrepareStatementSetterInstrumentation extends OraclePrepareStatementInstrumentation {
+
+
+    @Override
+    public InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
+        return new InstanceMethodsInterceptPoint[]{
+          new PSSetterDefinitionOfJDBCInstrumentation(false)
+        };
+    }
+
+}

--- a/oracle-10.x-plugin/src/main/resources/skywalking-plugin.def
+++ b/oracle-10.x-plugin/src/main/resources/skywalking-plugin.def
@@ -19,3 +19,4 @@ oracle-10.x=io.skywalking.apm.plugin.jdbc.oracle.define.ConnectionInstrumentatio
 oracle-10.x=io.skywalking.apm.plugin.jdbc.oracle.define.OracleCallableInstrumentation
 oracle-10.x=io.skywalking.apm.plugin.jdbc.oracle.define.OraclePrepareStatementInstrumentation
 oracle-10.x=io.skywalking.apm.plugin.jdbc.oracle.define.OracleStatementInstrumentation
+oracle-10.x=io.skywalking.apm.plugin.jdbc.oracle.define.OraclePrepareStatementSetterInstrumentation

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version> 
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -80,6 +81,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version> 
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -68,10 +68,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version> 
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -81,7 +80,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version> 
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <skywalking.version>8.2.0-SNAPSHOT</skywalking.version>
+        <skywalking.version>8.2.0</skywalking.version>
         <shade.package>org.apache.skywalking.apm.dependencies</shade.package>
         <shade.net.bytebuddy.source>net.bytebuddy</shade.net.bytebuddy.source>
         <shade.net.bytebuddy.target>${shade.package}.${shade.net.bytebuddy.source}</shade.net.bytebuddy.target>
@@ -69,8 +69,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -45,20 +45,20 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>3.5.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>1.6.4</version>
+            <version>2.0.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>1.6.4</version>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
1. Create a new class named OraclePrepareStatementSetterInstrumentation which is extend from OraclePrepareStatementInstrumentation
2. Add some lines in PreparedStatementExecuteMethodsInterceptor to process the sql parameter
3. remove the snapshot suffix from pom.xml, change the compiler from 1.6 to 8
4. remove the invalid content from travis.yml
5. Add OraclePrepareStatementSetterInstrumentation in the bottom of skywalking-plugin.def